### PR TITLE
Update projects to demonstrate different exclusion behaviour

### DIFF
--- a/sample-gradle-app/build.gradle
+++ b/sample-gradle-app/build.gradle
@@ -4,6 +4,5 @@ repositories {
 	mavenLocal()
 }
 dependencies {
-    compile 'org.springframework:spring-beans:4.2.6.RELEASE'
     compile 'com.kilo:sample-maven-lib:1.0.0-SNAPSHOT'
 }

--- a/sample-maven-app/pom.xml
+++ b/sample-maven-app/pom.xml
@@ -19,11 +19,6 @@
 	</build>
     <dependencies>
     	<dependency>
-    		<groupId>org.springframework</groupId>
-    		<artifactId>spring-beans</artifactId>
-    		<version>4.2.6.RELEASE</version>
-    	</dependency>
-    	<dependency>
     		<groupId>com.kilo</groupId>
     		<artifactId>sample-maven-lib</artifactId>
     		<version>1.0.0-SNAPSHOT</version>

--- a/sample-maven-library/pom.xml
+++ b/sample-maven-library/pom.xml
@@ -29,5 +29,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-beans</artifactId>
+			<version>4.2.6.RELEASE</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This PR updates the projects to demonstrate the different exclusion behaviour shown by Maven and Gradle.

Maven excludes commons logging:

```
$ mvn dependency:tree
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building sample-maven-app 1.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ sample-maven-app ---
[INFO] com.kilo:sample-maven-app:jar:1.0.0-SNAPSHOT
[INFO] \- com.kilo:sample-maven-lib:jar:1.0.0-SNAPSHOT:compile
[INFO]    +- org.springframework:spring-core:jar:4.2.6.RELEASE:compile
[INFO]    \- org.springframework:spring-beans:jar:4.2.6.RELEASE:compile
```

Gradle does not:

```
$ ./gradlew dependencies --configuration compile
:dependencies

------------------------------------------------------------
Root project
------------------------------------------------------------

compile - Dependencies for source set 'main'.
\--- com.kilo:sample-maven-lib:1.0.0-SNAPSHOT
     +--- org.springframework:spring-core:4.2.6.RELEASE
     |    \--- commons-logging:commons-logging:1.2
     \--- org.springframework:spring-beans:4.2.6.RELEASE
          \--- org.springframework:spring-core:4.2.6.RELEASE (*)
```
